### PR TITLE
Fix repos link issue

### DIFF
--- a/mkdocs_git_committers_plugin/plugin.py
+++ b/mkdocs_git_committers_plugin/plugin.py
@@ -59,7 +59,7 @@ class GitCommittersPlugin(BasePlugin):
                         "login": c.committer.login,
                         "avatar": c.committer.avatar_url,
                         "last_commit": c.committer.avatar_url,
-                        "repos": (self.config['enterprise_hostname'] or 'https://github.com/') + c.committer.login
+                        "repos": 'https://' + (self.config['enterprise_hostname'] or 'github.com') + '/' + c.committer.login
                     })
         return unique_committers
                 


### PR DESCRIPTION
Sorry @byrnereese, looks like I overlooked something.

The expected `enterprise_hostname` format is `github.foo.com` so I needed to update the `repos` property to support the hostname properly.

The GHE anchors to the user's profiles will end up malformed without this change.