### PR TITLE
Fix IndexError in get_last_commit

### DIFF
--- a/mkdocs_git_committers_plugin/plugin.py
+++ b/mkdocs_git_committers_plugin/plugin.py
@@ -43,9 +43,11 @@ class GitCommittersPlugin(BasePlugin):
     def get_last_commit(self, path):
         since = datetime.now() - timedelta(days=1)
         commits = self.repo.get_commits(path=path, sha=self.branch)
-        last = commits[0]
-        return last
-                    
+        if commits.totalCount > 0:
+            return commits[0]
+        else:
+            return None
+
     def get_committers(self, path):
         seen_committers = []
         unique_committers = []


### PR DESCRIPTION
Fix an error in `get_last_commit` when running "mkdocs serve" with a newly created file which has no commit history.

```
  File "/home/ojacques/.local/lib/python3.6/site-packages/mkdocs_git_committers_plugin/plugin.py", line 46, in get_last_commit
    last = commits[0]
  File "/home/ojacques/.local/lib/python3.6/site-packages/github/PaginatedList.py", line 56, in __getitem__
    return self.__elements[index]
IndexError: list index out of range
```