### PR TITLE
remove `string_types`

### DIFF
--- a/mkdocs_git_committers_plugin/plugin.py
+++ b/mkdocs_git_committers_plugin/plugin.py
@@ -13,11 +13,11 @@ from github import Github
 class GitCommittersPlugin(BasePlugin):
 
     config_scheme = (
-        ('enterprise_hostname', config_options.Type(mkdocs_utils.string_types, default='')),
-        ('repository', config_options.Type(mkdocs_utils.string_types, default='')),
-        ('branch', config_options.Type(mkdocs_utils.string_types, default='master')),
-        ('docs_path', config_options.Type(mkdocs_utils.string_types, default='docs/')),
-        ('token', config_options.Type(mkdocs_utils.string_types, default='')),
+        ('enterprise_hostname', config_options.Type(str, default='')),
+        ('repository', config_options.Type(str, default='')),
+        ('branch', config_options.Type(str, default='master')),
+        ('docs_path', config_options.Type(str, default='docs/')),
+        ('token', config_options.Type(str, default='')),
     )
 
     def __init__(self):


### PR DESCRIPTION
A future new release of mkdocs would break this plugin because of the deprecated `string_types`. 

See https://github.com/timvink/mkdocs-git-revision-date-localized-plugin/issues/8 for details