### PR TITLE
fixed missing github user link when using mkdocs-material

### DIFF
--- a/mkdocs_git_committers_plugin/plugin.py
+++ b/mkdocs_git_committers_plugin/plugin.py
@@ -62,6 +62,7 @@ class GitCommittersPlugin(BasePlugin):
                 unique_committers.append({
                     "name": c.author.name,
                     "login": c.author.login,
+                    "url": f"https://github.com/{c.author.login}",
                     "avatar": c.author.avatar_url,
                     "last_commit": c.author.avatar_url,
                     "repos": 'https://' + (self.config['enterprise_hostname'] or 'github.com') + '/' + c.author.login
@@ -73,6 +74,7 @@ class GitCommittersPlugin(BasePlugin):
         contrib = {
             "name": user.name,
             "login": user.login,
+            "url": f"https://github.com/{user.login}",
             "avatar": user.avatar_url,
             "last_commit": user.avatar_url,
             "repos": 'https://' + (self.config['enterprise_hostname'] or 'github.com') + '/' + user.login


### PR DESCRIPTION
**Bug Description**

When using the [mkdocs-material](https://github.com/squidfunk/mkdocs-material) theme, it's expected that the avatar images should include href links leading to the profile pages of the authors. Nonetheless, as a result of the absence of the `url` key in the `unique_committers` section, the link is not present.

**Fix**

added `url` key.